### PR TITLE
Improve Ranking page animations

### DIFF
--- a/src/components/ListaMiembrosAnimada/ListaMiembrosAnimada.jsx
+++ b/src/components/ListaMiembrosAnimada/ListaMiembrosAnimada.jsx
@@ -3,16 +3,11 @@
 import React from 'react';
 import TarjetaMiembro from '../TarjetaMiembro/TarjetaMiembro';
 
-const ListaMiembrosAnimada = ({ miembros, medalla }) => {
+const ListaMiembrosAnimada = ({ miembros }) => {
   return (
     <>
       {miembros.map((miembro, index) => (
-        <TarjetaMiembro
-          key={index}
-          index={index}
-          miembro={miembro}
-          medalla={medalla}
-        />
+        <TarjetaMiembro key={index} index={index} miembro={miembro} />
       ))}
     </>
   );

--- a/src/components/TarjetaMiembro/TarjetaMiembro.jsx
+++ b/src/components/TarjetaMiembro/TarjetaMiembro.jsx
@@ -1,72 +1,74 @@
 import React from 'react';
-import { Card, CardContent, Box, Typography, Avatar, IconButton } from '@mui/material';
+import { Card, CardContent, Box, Typography, Avatar, IconButton, LinearProgress } from '@mui/material';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import { motion } from 'framer-motion';
 
-const generarMiembros = () => {
-  const nombres = ['Ana', 'Luis', 'Carlos', 'Valeria', 'Marcos', 'Sofía', 'Elena'];
-  return Array.from({ length: 6 }, (_, i) => ({
-    nombre: nombres[Math.floor(Math.random() * nombres.length)],
-    porcentaje: Math.floor(Math.random() * 40) + 60,
-    medalla: ['🥇', '🥈', '🥉'][i] || '',
-    destacado: i === 0
-  }));
-};
-
-const TarjetaMiembro = () => {
-  const miembros = generarMiembros();
-
+const TarjetaMiembro = ({ miembro, index }) => {
   return (
-    <Box sx={{ maxWidth: '70%', mr: 'auto' }}>
-      {miembros.map((miembro, index) => (
-        <motion.div
-          key={index}
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: index * 0.2, duration: 0.5 }}
-        >
-          <Card
-            variant="outlined"
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.2, duration: 0.5 }}
+      style={{ marginBottom: '16px' }}
+    >
+      <Card
+        variant="outlined"
+        sx={{
+          width: '100%',
+          borderColor: miembro.destacado ? 'orange' : '#e0e0e0',
+          boxShadow: miembro.destacado ? '0 0 12px rgba(255,165,0,0.3)' : '',
+          borderWidth: miembro.destacado ? '2px' : '1px',
+          backgroundColor: miembro.destacado ? '#fffdf7' : '#fff'
+        }}
+      >
+        <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Typography
+            fontSize="1.8rem"
             sx={{
-              mb: 2,
-              width: '100%',
-              borderColor: miembro.destacado ? 'orange' : '#e0e0e0',
-              boxShadow: miembro.destacado ? '0 0 12px rgba(255,165,0,0.3)' : '',
-              borderWidth: miembro.destacado ? '2px' : '1px',
-              backgroundColor: miembro.destacado ? '#fffdf7' : '#fff',
+              color:
+                miembro.medalla === '🥇'
+                  ? '#FFD700'
+                  : miembro.medalla === '🥈'
+                  ? '#C0C0C0'
+                  : miembro.medalla === '🥉'
+                  ? '#CD7F32'
+                  : 'inherit'
             }}
           >
-            <CardContent sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-              <Typography fontSize="1.8rem" sx={{
-                color:
-                  miembro.medalla === '🥇' ? '#FFD700' :
-                  miembro.medalla === '🥈' ? '#C0C0C0' :
-                  miembro.medalla === '🥉' ? '#CD7F32' :
-                  'inherit'
-              }}>
-                {miembro.medalla}
+            {miembro.medalla}
+          </Typography>
+          <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Avatar sx={{ mr: 2, bgcolor: '#ccc' }} />
+              <Typography fontWeight={miembro.destacado ? 'bold' : 'normal'}>
+                {miembro.nombre}
               </Typography>
-              <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <Avatar sx={{ mr: 2, bgcolor: '#ccc' }} />
-                  <Typography fontWeight={miembro.destacado ? 'bold' : 'normal'}>
-                    {miembro.nombre}
-                  </Typography>
-                </Box>
-                <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                  <Typography variant="h6" sx={{ mr: 1 }}>
-                    {miembro.porcentaje}%
-                  </Typography>
-                  <IconButton>
-                    <ArrowForwardIosIcon fontSize="small" />
-                  </IconButton>
-                </Box>
-              </Box>
-            </CardContent>
-          </Card>
-        </motion.div>
-      ))}
-    </Box>
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 120 }}>
+              <Typography variant="body2" sx={{ width: 32 }}>
+                {miembro.porcentaje}%
+              </Typography>
+              <LinearProgress
+                variant="determinate"
+                value={miembro.porcentaje}
+                sx={{
+                  flexGrow: 1,
+                  height: 8,
+                  borderRadius: 5,
+                  backgroundColor: '#f1f5f9',
+                  '& .MuiLinearProgress-bar': {
+                    backgroundImage: 'linear-gradient(90deg,#E54EB5,#FEB101)'
+                  }
+                }}
+              />
+              <IconButton size="small">
+                <ArrowForwardIosIcon fontSize="inherit" />
+              </IconButton>
+            </Box>
+          </Box>
+        </CardContent>
+      </Card>
+    </motion.div>
   );
 };
 

--- a/src/pages/Ranking/Ranking.jsx
+++ b/src/pages/Ranking/Ranking.jsx
@@ -1,15 +1,12 @@
 import React from 'react';
-import {
-  Box,
-  Typography,
-  Avatar,
-} from '@mui/material';
+import { Box, Typography, Avatar } from '@mui/material';
+import { motion } from 'framer-motion';
 import './Ranking.css';
 import Layout from '../../components/Layout/Layout';
-import medalla from '../../assets/medalla.png';
 import EncabezadoRanking from '../../components/EncabezadoRanking/EncabezadoRanking';
 import ListaMiembrosAnimada from '../../components/ListaMiembrosAnimada/ListaMiembrosAnimada';
 import ResumenRankingDerecha from '../../components/ResumenRankingDerecha/ResumenRankingDerecha';
+import MotionReveal from '../../components/animations/MotionReveal';
 
 const miembros = [
   { nombre: 'Luis Castañeda', porcentaje: 78 },
@@ -25,54 +22,69 @@ const miembros = [
 const Ranking = () => {
   return (
     <Layout>
-      <Box sx={{ px: 4, py: 3, position: 'relative' }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-          <Typography variant="h5" fontWeight="bold">Brújula Creativa</Typography>
-
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-              <Typography variant="body2" fontWeight="medium" sx={{ color: '#FC083B' }}>Proyectos Activos</Typography>
-              <Typography variant="h6" fontWeight="bold">16</Typography>
+      <Box
+        component={motion.div}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.6 }}
+        sx={{ px: 4, py: 3, position: 'relative' }}
+      >
+        <MotionReveal index={1}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+            <Typography variant="h5" fontWeight="bold">Brújula Creativa</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <Typography variant="body2" fontWeight="medium" sx={{ color: '#FC083B' }}>Proyectos Activos</Typography>
+                <Typography variant="h6" fontWeight="bold">16</Typography>
+              </Box>
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <Typography variant="body2" fontWeight="medium" sx={{ color: '#FB8C00' }}>Próximos Proyectos</Typography>
+                <Typography variant="h6" fontWeight="bold">08</Typography>
+              </Box>
+              <Avatar sx={{ bgcolor: '#ccc', width: 40, height: 40 }} />
             </Box>
-            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-              <Typography variant="body2" fontWeight="medium" sx={{ color: '#FB8C00' }}>Próximos Proyectos</Typography>
-              <Typography variant="h6" fontWeight="bold">08</Typography>
-            </Box>
-            <Avatar sx={{ bgcolor: '#ccc', width: 40, height: 40 }} />
           </Box>
-        </Box>
+        </MotionReveal>
 
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 1, mb: 3 }}>
-          <h1>Ranking</h1>
-          <Box>
-            <Typography variant="body2" fontWeight="medium">Integrantes del equipo (26)</Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
-              {[1, 2, 3, 4].map((i) => (
-                <Avatar key={i} sx={{ width: 30, height: 30, bgcolor: '#ddd' }} />
-              ))}
-              <Box sx={{
-                width: 30,
-                height: 30,
-                borderRadius: '50%',
-                bgcolor: 'orange',
-                color: '#fff',
-                fontSize: '0.75rem',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}>
-                20+
+        <MotionReveal index={2}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 1, mb: 3 }}>
+            <h1 style={{ color: '#E54EB5' }}>Ranking</h1>
+            <Box>
+              <Typography variant="body2" fontWeight="medium">Integrantes del equipo (26)</Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
+                {[1, 2, 3, 4].map((i) => (
+                  <Avatar key={i} sx={{ width: 30, height: 30, bgcolor: '#ddd' }} />
+                ))}
+                <Box
+                  sx={{
+                    width: 30,
+                    height: 30,
+                    borderRadius: '50%',
+                    bgcolor: 'orange',
+                    color: '#fff',
+                    fontSize: '0.75rem',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  20+
+                </Box>
               </Box>
             </Box>
           </Box>
-        </Box>
+        </MotionReveal>
 
-        <EncabezadoRanking />
+        <MotionReveal index={3}>
+          <EncabezadoRanking />
+        </MotionReveal>
 
-        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
-          <ListaMiembrosAnimada miembros={miembros} medalla={medalla} />
-          <ResumenRankingDerecha miembros={miembros} />
-        </Box>
+        <MotionReveal index={4}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 4 }}>
+            <ListaMiembrosAnimada miembros={miembros} />
+            <ResumenRankingDerecha miembros={miembros} />
+          </Box>
+        </MotionReveal>
       </Box>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- make Ranking page dynamic with MotionReveal and motion container
- redesign member card to use LinearProgress and animations
- update member list props

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418f24359c83268e6584fa70aa9ff3