### PR TITLE
Add ranking podium animation

### DIFF
--- a/src/components/PodiumRanking/PodiumRanking.css
+++ b/src/components/PodiumRanking/PodiumRanking.css
@@ -1,0 +1,18 @@
+.podium-container {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.podium {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.podium-bar {
+  width: 80px;
+  border-radius: 4px 4px 0 0;
+}

--- a/src/components/PodiumRanking/PodiumRanking.jsx
+++ b/src/components/PodiumRanking/PodiumRanking.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Box, Typography, Avatar } from '@mui/material';
+import { motion } from 'framer-motion';
+import './PodiumRanking.css';
+
+const PodiumRanking = ({ miembros }) => {
+  const orden = [1, 0, 2]; // segundo, primero, tercero
+  const colores = ['#C0C0C0', '#FFD700', '#CD7F32'];
+
+  return (
+    <Box className="podium-container">
+      {orden.map((pos, idx) => {
+        const m = miembros[pos];
+        if (!m) return null;
+        const altura = m.porcentaje * 1.5;
+        return (
+          <Box key={m.nombre} className="podium">
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: idx * 0.2 + 0.4 }}
+            >
+              <Typography fontSize="1.8rem">{m.medalla}</Typography>
+            </motion.div>
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{ delay: idx * 0.2 + 0.5 }}
+            >
+              <Avatar sx={{ bgcolor: '#ccc', width: 48, height: 48, mb: 1 }} />
+            </motion.div>
+            <motion.div
+              className="podium-bar"
+              style={{ backgroundColor: colores[idx] }}
+              initial={{ height: 0 }}
+              animate={{ height: altura }}
+              transition={{ duration: 0.6, delay: idx * 0.2 }}
+            />
+            <Typography variant="body2" sx={{ mt: 1, textAlign: 'center' }}>
+              {m.nombre}
+            </Typography>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default PodiumRanking;

--- a/src/pages/Ranking/Ranking.jsx
+++ b/src/pages/Ranking/Ranking.jsx
@@ -6,6 +6,7 @@ import Layout from '../../components/Layout/Layout';
 import EncabezadoRanking from '../../components/EncabezadoRanking/EncabezadoRanking';
 import ListaMiembrosAnimada from '../../components/ListaMiembrosAnimada/ListaMiembrosAnimada';
 import ResumenRankingDerecha from '../../components/ResumenRankingDerecha/ResumenRankingDerecha';
+import PodiumRanking from '../../components/PodiumRanking/PodiumRanking';
 import MotionReveal from '../../components/animations/MotionReveal';
 
 const miembros = [
@@ -80,6 +81,10 @@ const Ranking = () => {
         </MotionReveal>
 
         <MotionReveal index={4}>
+          <PodiumRanking miembros={miembros.slice(0, 3)} />
+        </MotionReveal>
+
+        <MotionReveal index={5}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 4 }}>
             <ListaMiembrosAnimada miembros={miembros} />
             <ResumenRankingDerecha miembros={miembros} />


### PR DESCRIPTION
## Summary
- add PodiumRanking component with framer-motion animation
- create styles for the new podium
- show podium for top 3 members on Ranking page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841941627d08326904f6f1f74cfb242